### PR TITLE
Prepare environment before benchmark

### DIFF
--- a/lib/bmark/server.ex
+++ b/lib/bmark/server.ex
@@ -1,6 +1,6 @@
 defmodule Bmark.Server do
   use GenServer
-  
+
   @moduledoc """
   The Bmark server maintains a list of benchmarks registered with the `bmark` module.  It
   can also run all benchmarks in the list.
@@ -28,8 +28,13 @@ defmodule Bmark.Server do
     {
       entry.module,
       entry.name,
-      Stream.repeatedly(fn -> time(entry) end) |> Stream.take(entry.runs)
+      Stream.repeatedly(fn -> prepare_and_time(entry) end) |> Stream.take(entry.runs)
     }
+  end
+
+  defp prepare_and_time(entry) do
+    :erlang.garbage_collect
+    time(entry)
   end
 
   defp time(entry) do
@@ -46,7 +51,7 @@ defmodule Bmark.Server do
 
   @doc """
   Add a new benchmark to the list.
-  
+
   `module`  - The module that contains the bmark function.
   `name`    - The benchmark name (also the name of the underlying function)
   `runs`    - The number of times to run the benchmark.


### PR DESCRIPTION
Trigger GC before the benchmark starts this cleans out any GC work not
related to the benchmark itself.

Fixes #9
